### PR TITLE
chore(devcontainer): GitHub Codespaces for Solana (Anchor + Python)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+# System packages often needed by Solana CLI, Anchor builds, and Python deps
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+ && apt-get install -y --no-install-recommends \
+    build-essential pkg-config libssl-dev libudev-dev libsqlite3-dev \
+    curl git ca-certificates jq unzip python3-venv python3-dev \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,50 @@
+{
+  "name": "Solana Crowdfund (Anchor + Python)",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {},
+    "ghcr.io/devcontainers/features/node:1": { "version": "lts" },
+    "ghcr.io/devcontainers/features/rust:1": { "profile": "minimal" },
+    "ghcr.io/devcontainers/features/python:1": { "version": "3.11" }
+  },
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "containerEnv": {
+    "ANCHOR_PROVIDER_URL": "https://api.devnet.solana.com",
+    "ANCHOR_WALLET": "/workspaces/${localWorkspaceFolderBasename}/.devcontainer/keys/id.json"
+  },
+  "postCreateCommand": "bash scripts/devcontainer-setup.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "vadimcn.vscode-lldb",
+        "serayuzgur.crates",
+        "tamasfe.even-better-toml",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "esbenp.prettier-vscode",
+        "oderwat.indent-rainbow"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "rust-analyzer.check.command": "clippy",
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestArgs": ["-q"],
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  },
+  "remoteUser": "vscode",
+  "updateContentCommand": "",
+  "onCreateCommand": "",
+  "runArgs": [
+    "--env=SOLANA_INSTALL_UPDATE_SKIP_PROMPT=1"
+  ],
+  "mounts": [
+    "source=${localEnv:HOME}/.cargo,target=/home/vscode/.cargo,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.rustup,target=/home/vscode/.rustup,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.npm,target=/home/vscode/.npm,type=bind,consistency=cached"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ node_modules/
 .DS_Store
 dist/
 coverage/
-.vscode/
 .venv/
 *.log
 **/__pycache__/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Launch init_campaign.py",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/client_py/init_campaign.py",
+      "console": "integratedTerminal",
+      "justMyCode": true
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,49 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Anchor: Build",
+      "type": "shell",
+      "command": "anchor build",
+      "problemMatcher": []
+    },
+    {
+      "label": "Anchor: Deploy (devnet)",
+      "type": "shell",
+      "command": "anchor deploy",
+      "problemMatcher": []
+    },
+    {
+      "label": "Solana: Local validator",
+      "type": "shell",
+      "command": "solana-test-validator",
+      "isBackground": true,
+      "problemMatcher": []
+    },
+    {
+      "label": "Python: Init campaign",
+      "type": "shell",
+      "command": "source .venv/bin/activate && python client_py/init_campaign.py"
+    },
+    {
+      "label": "Python: Contribute 0.1",
+      "type": "shell",
+      "command": "source .venv/bin/activate && python client_py/contribute.py"
+    },
+    {
+      "label": "Python: Withdraw",
+      "type": "shell",
+      "command": "source .venv/bin/activate && python client_py/withdraw.py"
+    },
+    {
+      "label": "Python: Refund",
+      "type": "shell",
+      "command": "source .venv/bin/activate && python client_py/refund.py"
+    },
+    {
+      "label": "Python: Tests",
+      "type": "shell",
+      "command": "source .venv/bin/activate && pytest -q"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ python client_py/withdraw.py
 python client_py/refund.py
 ```
 
+## Codespaces
+- Click **Code → Create codespace on main**.
+- First boot runs `.devcontainer/scripts/devcontainer-setup.sh`:
+  - Installs Solana CLI, Anchor CLI, Rust, Node, Python deps
+  - Generates a devnet keypair at `.devcontainer/keys/id.json`
+  - Funds it with a small devnet airdrop
+- Use **Tasks**: `Terminal → Run Task…` → e.g. *Anchor: Build*, *Python: Init campaign*.
+
 ## Local Testing
 ```bash
 solana-test-validator   # run in a separate terminal (optional)

--- a/scripts/devcontainer-setup.sh
+++ b/scripts/devcontainer-setup.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> Installing Solana CLI (stable)…"
+sh -c "$(curl -sSfL https://release.solana.com/stable/install)"
+export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
+
+echo "==> Solana version:"
+solana --version || true
+
+echo "==> Installing Anchor CLI…"
+npm i -g @coral-xyz/anchor-cli
+anchor --version || true
+
+# Make sure our devnet config is set
+echo "==> Configuring Solana devnet…"
+solana config set --url https://api.devnet.solana.com
+
+# Create a workspace keypair for Codespaces (not your local machine keys)
+WALLET="/workspaces/$(basename "$PWD")/.devcontainer/keys/id.json"
+mkdir -p "$(dirname "$WALLET")"
+if [ ! -f "$WALLET" ]; then
+  echo "==> Generating devnet keypair for this Codespace…"
+  solana-keygen new -o "$WALLET" --no-bip39-passphrase --force
+fi
+solana config set --keypair "$WALLET"
+
+# Airdrop some devnet SOL to make first txs smoother (ignore errors if faucet is busy)
+echo "==> Requesting airdrop (2 SOL)…"
+solana airdrop 2 || true
+solana balance || true
+
+# Python: venv + deps for the client
+echo "==> Python venv + client deps…"
+python3 -m venv .venv
+source .venv/bin/activate
+pip -q install --upgrade pip
+if [ -f client_py/requirements.txt ]; then
+  pip -q install -r client_py/requirements.txt
+fi
+
+# If Anchor workspace exists, try building so IDL is available to anchorpy
+if [ -f Anchor.toml ]; then
+  echo "==> anchor build (to produce target/idl)…"
+  anchor build || true
+fi
+
+# Quality of life
+git config --global --add safe.directory /workspaces/$(basename "$PWD")
+echo "==> Setup complete."


### PR DESCRIPTION
## Summary
- add devcontainer setup for GitHub Codespaces with Solana, Anchor, Rust, Node, and Python
- provide VS Code tasks and launch configs for common workflows
- document Codespaces usage in README and allow `.vscode` in git

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68964c84767483279c6cacf08b1d9045